### PR TITLE
Add weather units and API key options

### DIFF
--- a/options.html
+++ b/options.html
@@ -101,6 +101,22 @@
                 >
                     Shows the weather widget in the sidebar
                 </span>
+                <!-- Weather Units -->            
+                <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label">
+                    <label for="user">Weather Units</label>
+                    <select class="mdl-textfield__input" id="weather-units" name="weather-units">
+                        <option value="imperial">Imperial</option>
+                        <option value="metric">Metric</option>
+                        <option value="kelvin">Kelvin</option>
+                    </select>
+                </div>
+                <span
+                    class="mdl-tooltip mdl-tooltip--right"
+                    for="weather-units"
+                >
+                    Select the units you wish to see
+                </span>
+
                 <!-- Weather ZipCode -->
                 <div class="option" id="show-weather-zip-tooltip">
                     <form action="#">
@@ -124,6 +140,25 @@
                 >
                     Type the zipcode of the region you would like weather
                     information to show
+                </span>
+                <!-- Weather API Key -->
+                <div class="option" id="show-weather-api-key-tooltip">
+                    <form action="#">
+                        <div class="mdl-textfield mdl-js-textfield">
+                            <label for="user">OpenWeatherMap API Key</label>
+                            <input
+                                class="mdl-textfield__input"
+                                type="text"
+                                id="text-weather-api-key"
+                            />
+                        </div>
+                    </form>
+                </div>
+                <span
+                    class="mdl-tooltip mdl-tooltip--right"
+                    for="show-weather-api-key-tooltip"
+                >
+                    Type your API Key for https://openweathermap.org/api
                 </span>
             </div>
         </div>

--- a/options.js
+++ b/options.js
@@ -34,6 +34,15 @@ const SHOW_WEATHER_OPTION = {
     property: 'checked'
 }
 
+const WEATHER_API_KEY_OPTION = {
+    elementId: 'text-weather-api-key',
+    defaultValue: '',
+    storageKey: 'weatherApiKey',
+    loader: loadOrDefault,
+    mutator: weatherApiKeyChanged,
+    property: 'value'
+}
+
 const ZIPCODE_OPTION = {
     elementId: 'text-zipcode',
     defaultValue: 55421,
@@ -43,12 +52,24 @@ const ZIPCODE_OPTION = {
     property: 'value'
 }
 
+const UNITS_OPTION = {
+    elementId: 'weather-units',
+    defaultValue: 'imperial',
+    storageKey: 'weatherUnits',
+    loader: loadOrDefault,
+    mutator: weatherUnitsChanged,
+    property: 'value'
+}
+
+
 const OPTIONS = [
     SHOW_SIDEBAR_OPTION,
     SHOW_CLOCK_OPTION,
     SHOW_QUOTE_OPTION,
     SHOW_WEATHER_OPTION,
-    ZIPCODE_OPTION
+    ZIPCODE_OPTION,
+    WEATHER_API_KEY_OPTION,
+    UNITS_OPTION
 ]
 
 function loadOrDefault(option) {
@@ -66,33 +87,32 @@ function loadOrDefaultBoolean(option) {
     return loadOrDefault(option) == 'true' ? true : false
 }
 
-function updateOptionStorageFromEvent(option, inputEvent) {
-    localStorage.setItem(option.storageKey, inputEvent.target.value);
-}
-
 function switchSidebarChanged(inputEvent) {
-    console.log('switchSidebarChanged')
     localStorage.setItem(SHOW_SIDEBAR_OPTION.storageKey, inputEvent.target.checked)
 }
 
 function switchClockChanged(inputEvent) {
-    console.log('switchClockChanged')
     localStorage.setItem(SHOW_CLOCK_OPTION.storageKey, inputEvent.target.checked)
 }
 
 function switchQuoteChanged(inputEvent) {
-    console.log('switchQuoteChanged')
     localStorage.setItem(SHOW_QUOTE_OPTION.storageKey, inputEvent.target.checked)
 }
 
 function switchWeatherChanged(inputEvent) {
-    console.log('switchWeatherChanged')
     localStorage.setItem(SHOW_WEATHER_OPTION.storageKey, inputEvent.target.checked)
 }
 
 function zipcodeChanged(inputEvent) {
-    console.log('zipcodeChanged')
     localStorage.setItem(ZIPCODE_OPTION.storageKey, inputEvent.target.value)
+}
+
+function weatherApiKeyChanged(inputEvent) {
+    localStorage.setItem(WEATHER_API_KEY_OPTION.storageKey, inputEvent.target.value)
+}
+
+function weatherUnitsChanged(inputEvent) {
+    localStorage.setItem(UNITS_OPTION.storageKey, inputEvent.target.value)
 }
 
 function loadOptionsData() {

--- a/styles/options-styles.css
+++ b/styles/options-styles.css
@@ -28,7 +28,3 @@
     margin-bottom: 1em;
 }
 
-form label {
-    font-size: 0.9em;
-    text-transform: uppercase;
-}

--- a/weather.js
+++ b/weather.js
@@ -1,10 +1,12 @@
-const KEY = 'key'
-
 var IMPERIAL = "imperial"
 var METRIC = "metric"
-var units = IMPERIAL
+var KELVIN = "kelvin"
 
 var zipCode = options.zipcode
+var apiKey = options.weatherApiKey
+var units = options.weatherUnits
+
+console.log("units", units)
 
 function setTemp(data) {
     var suffix = ""
@@ -12,6 +14,8 @@ function setTemp(data) {
         suffix = ' \xB0F';
     } else if (units == METRIC) {
         suffix = ' \xB0C';
+    } else if (units == KELVIN) {
+        suffix = ' K';
     }
 
     document.getElementById("weather-temp").textContent = Math.round(data.main.temp) + suffix;
@@ -45,7 +49,7 @@ function fetchWeather() {
         // TODO: Handle errors
     }
 
-    request.open('GET', 'https://api.openweathermap.org/data/2.5/weather?zip=' + zipCode + ',us&units=' + units + '&appid&appid=' + KEY, true)
+    request.open('GET', 'https://api.openweathermap.org/data/2.5/weather?zip=' + zipCode + ',us&units=' + units + '&appid&appid=' + apiKey, true)
     request.send();
 }
 


### PR DESCRIPTION
# Description:

Adding configuration options for weather gadget.
1. API Key: this will allow the user to provide their own API key
2. Units: allows the user to select between imperial (farenheit), metric (celsius), and kelvin scales.

Minor change to label styling. Font sizing should be consistent with other options, and uppercasing makes the API key description harder to read.
