### PR TITLE
Refine options styling

### DIFF
--- a/options.html
+++ b/options.html
@@ -16,7 +16,7 @@
             </section>
             <!-- Show Sidebar -->
             <div class="mdl-card mdl-shadow--2dp options__card">
-                <div class="option" id="show-sidebar-tooltip">
+                <div class="option option-switch" id="show-sidebar-tooltip">
                     <label
                         class="mdl-switch mdl-js-switch mdl-js-ripple-effect"
                         for="switch-sidebar"
@@ -37,7 +37,7 @@
                     Shows the sidebar
                 </span>
                 <!-- Show Clock and Date -->
-                <div class="option" id="show-clock-tooltip">
+                <div class="option option-switch" id="show-clock-tooltip">
                     <label
                         class="mdl-switch mdl-js-switch mdl-js-ripple-effect"
                         for="switch-clock"
@@ -58,7 +58,7 @@
                     Shows the clock widget in the sidebar
                 </span>
                 <!-- Show Quote of the Day -->
-                <div class="option" id="show-quote-tooltip">
+                <div class="option option-switch" id="show-quote-tooltip">
                     <label
                         class="mdl-switch mdl-js-switch mdl-js-ripple-effect"
                         for="switch-quote"
@@ -81,7 +81,7 @@
                     Shows the quote widget in the sidebar
                 </span>
                 <!-- Show Weather -->
-                <div class="option" id="show-weather-tooltip">
+                <div class="option option-switch" id="show-weather-tooltip">
                     <label
                         class="mdl-switch mdl-js-switch mdl-js-ripple-effect"
                         for="switch-weather"
@@ -151,6 +151,7 @@
                                 type="text"
                                 id="text-weather-api-key"
                             />
+                            <label><a href="https://openweathermap.org/appid">How to get an API Key</a></label>
                         </div>
                     </form>
                 </div>

--- a/styles/options-styles.css
+++ b/styles/options-styles.css
@@ -25,6 +25,13 @@
 .option {
     width: fit-content;
     padding-right: 20px;
+}
+
+.option-switch {
     margin-bottom: 1em;
+}
+
+form {
+    margin: 0;
 }
 


### PR DESCRIPTION
# Description:

Minor tweaks to options and styling

1. Keep spacing the same between switch options but reduce space between text options by adding a new class to switches called "option-switch" and moving the margin-bottom parameter from ".option" to ".option-switch"
2. Decrease margin after form elements
3. Add a link to openweathermap.org API key documentation