### PR TITLE
Resolve Issue #9: Add NFL Score Data

### DIFF
--- a/html/happytab.html
+++ b/html/happytab.html
@@ -25,6 +25,7 @@
             <div class="nfl">
                 <p id="nfl-away-team"></p>
                 <p id="nfl-home-team"></p>
+                <p id="nfl-game-time"></p>
             </div>
         </div>
         <div id="main">

--- a/html/happytab.html
+++ b/html/happytab.html
@@ -22,6 +22,10 @@
                 <p id="quote-of-the-day-quote"></p>
                 <p id="quote-of-the-day-author"></p>
             </div>
+            <div class="nfl">
+                <p id="nfl-away-team"></p>
+                <p id="nfl-home-team"></p>
+            </div>
         </div>
         <div id="main">
             <div id="options"></div>
@@ -31,6 +35,7 @@
     <script src="../src/options-data.js"></script>
     <script src="../src/background.js"></script>
     <script src="../src/quote_of_the_day.js"></script>
+    <script src="../src/nfl.js"></script>
     <script src="../src/weather.js"></script>
     <script src="../src/clock.js"></script>
     <script src="../src/links.js"></script>

--- a/html/options.html
+++ b/html/options.html
@@ -80,6 +80,29 @@
                 >
                     Shows the quote widget in the sidebar
                 </span>
+                <!-- Show NFL Score -->
+                <div class="option option-switch" id="show-nfl-tooltip">
+                    <label
+                        class="mdl-switch mdl-js-switch mdl-js-ripple-effect"
+                        for="switch-nfl"
+                    >
+                        <input
+                            type="checkbox"
+                            id="switch-nfl"
+                            class="mdl-switch__input"
+                            checked
+                        />
+                        <span class="mdl-switch__label"
+                            >Show NFL Score</span
+                        >
+                    </label>
+                </div>
+                <span
+                    class="mdl-tooltip mdl-tooltip--right"
+                    for="show-nfl-tooltip"
+                >
+                    Shows the NFL Score widget in the sidebar
+                </span>
                 <!-- Show Weather -->
                 <div class="option option-switch" id="show-weather-tooltip">
                     <label
@@ -141,6 +164,7 @@
                     Type the zipcode of the region you would like weather
                     information to show
                 </span>
+                <div class="option" id=""
                 <!-- Weather API Key -->
                 <div class="option" id="show-weather-api-key-tooltip">
                     <form action="#">
@@ -160,6 +184,25 @@
                     for="show-weather-api-key-tooltip"
                 >
                     Type your API Key for https://openweathermap.org/api
+                </span>
+                <!-- NFL TEAM -->
+                <div class="option" id="nfl-team-tooltip">
+                    <form action="#">
+                        <div class="mdl-textfield mdl-js-textfield">
+                            <label for="user">NFL TEAM</label>
+                            <input
+                                class="mdl-textfield__input"
+                                type="text"
+                                id="nfl-team"
+                            />
+                        </div>
+                    </form>
+                </div>
+                <span
+                    class="mdl-tooltip mdl-tooltip--right"
+                    for="nfl-team-tooltip"
+                >
+                    Type your favorite NFL Team Abbreviation
                 </span>
             </div>
         </div>

--- a/html/options.html
+++ b/html/options.html
@@ -187,16 +187,43 @@
                 </span>
                 <!-- NFL TEAM -->
                 <div class="option" id="nfl-team-tooltip">
-                    <form action="#">
                         <div class="mdl-textfield mdl-js-textfield">
-                            <label for="user">NFL TEAM</label>
-                            <input
-                                class="mdl-textfield__input"
-                                type="text"
-                                id="nfl-team"
-                            />
-                        </div>
-                    </form>
+                        <label for="user">NFL TEAM</label>
+                        <select class="mdl-textfield__input" id="nfl-team" name="nfl-team">
+                            <option value="ari">ARI</option>
+                            <option value="atl">ATL</option>
+                            <option value="bal">BAL</option>
+                            <option value="buf">BUF</option>
+                            <option value="car">CAR</option>
+                            <option value="chi">CHI</option>
+                            <option value="cin">CIN</option>
+                            <option value="cle">CLE</option>
+                            <option value="dal">DAL</option>
+                            <option value="den">DEN</option>
+                            <option value="det">DET</option>
+                            <option value="gb">GB</option>
+                            <option value="hou">HOU</option>
+                            <option value="ind">IND</option>
+                            <option value="jax">JAX</option>
+                            <option value="kc">KC</option>
+                            <option value="lac">LAC</option>
+                            <option value="lar">LAR</option>
+                            <option value="mia">MIA</option>
+                            <option value="min">MIN</option>
+                            <option value="ne">NE</option>
+                            <option value="no">NO</option>
+                            <option value="nyg">NYG</option>
+                            <option value="nyj">NYJ</option>
+                            <option value="oak">OAK</option>
+                            <option value="phi">PHI</option>
+                            <option value="pit">PIT</option>
+                            <option value="sea">SEA</option>
+                            <option value="sf">SF</option>
+                            <option value="tb">TB</option>
+                            <option value="ten">TEN</option>
+                            <option value="was">WAS</option>
+                        </select>
+                    </div>
                 </div>
                 <span
                     class="mdl-tooltip mdl-tooltip--right"

--- a/src/nfl.js
+++ b/src/nfl.js
@@ -1,0 +1,51 @@
+var request = new XMLHttpRequest()
+const team = options.nflTeam.toUpperCase();
+var homeScore, awayScor, homeTeam, awayTeam;
+
+function renderScore() {
+    document.getElementById("nfl-away-team").textContent = awayTeam + " - " + awayScore;
+    document.getElementById("nfl-home-team").textContent = homeTeam + " - " + homeScore;
+}
+
+function renderError() {
+    document.getElementById("nfl-away-team").textContent = "No Game Found";
+}
+
+function searchForTeam(xml) {
+    var scores = xml.getElementsByTagName('g');
+    for (x = 0; x < scores.length; x++) {         
+        if (scores[x].getAttribute('v') == team || scores[x].getAttribute('h') == team) {
+            homeTeam = scores[x].getAttribute('h');
+            awayTeam = scores[x].getAttribute('v');
+            homeScore = scores[x].getAttribute('hs');
+            awayScore = scores[x].getAttribute('vs');
+            renderScore();
+            return;
+        }
+    }
+    renderError();
+}
+
+function fetchScore () {
+    const request = new XMLHttpRequest();
+    request.timeout = 2000;
+    request.onreadystatechange = function(e) {
+        if (request.readyState === 4) {
+            if (request.status === 200) {
+                parser = new DOMParser();
+                var scores = parser.parseFromString(request.response,"text/xml");
+                searchForTeam(scores);
+            } else {
+                renderError();
+            }
+        }
+    }
+    request.ontimeout = function () {
+    }
+    request.open('GET', 'http://www.nfl.com/liveupdate/scorestrip/ss.xml', true)
+    request.send();
+}
+
+if (options.showNFL) {
+    fetchScore();
+}

--- a/src/nfl.js
+++ b/src/nfl.js
@@ -1,9 +1,12 @@
 var request = new XMLHttpRequest()
 const team = options.nflTeam.toUpperCase();
-var homeScore, awayScore, homeTeam, awayTeam, quarter, timeReamining;
+var homeScore, awayScore, homeTeam, awayTeam, quarter, timeReamining, day, time;
 
 function renderScore() {
-    var clock = timeReamining === null ? "Not Live" : "Q" + quarter + " - " + timeReamining;
+    var clock = timeReamining != null ? "Q" + quarter + " - " + timeReamining : 
+                    quarter === "F" ? "Final" : 
+                    quarter === "P" ? "Game at " + time + "PM EST/EDT " + day :
+                    quarter === "H" ? "Half-Time" : "Please check schedule for game time";
     document.getElementById("nfl-away-team").textContent = awayTeam + " - " + awayScore;
     document.getElementById("nfl-home-team").textContent = homeTeam + " - " + homeScore;
     document.getElementById("nfl-game-time").textContent = clock;
@@ -22,9 +25,9 @@ function searchForTeam(xml) {
             homeScore = scores[x].getAttribute('hs');
             awayScore = scores[x].getAttribute('vs');
             timeReamining = scores[x].getAttribute('k');
-            if (timeReamining != null) {
-                quarter = scores[x].getAttribute('q');
-            }
+            quarter = scores[x].getAttribute('q');
+            day = scores[x].getAttribute('d');
+            time = scores[x].getAttribute('t');
             renderScore();
             return;
         }

--- a/src/nfl.js
+++ b/src/nfl.js
@@ -1,10 +1,12 @@
 var request = new XMLHttpRequest()
 const team = options.nflTeam.toUpperCase();
-var homeScore, awayScor, homeTeam, awayTeam;
+var homeScore, awayScore, homeTeam, awayTeam, quarter, timeReamining;
 
 function renderScore() {
+    var clock = timeReamining === null ? "Not Live" : "Q" + quarter + " - " + timeReamining;
     document.getElementById("nfl-away-team").textContent = awayTeam + " - " + awayScore;
     document.getElementById("nfl-home-team").textContent = homeTeam + " - " + homeScore;
+    document.getElementById("nfl-game-time").textContent = clock;
 }
 
 function renderError() {
@@ -19,6 +21,10 @@ function searchForTeam(xml) {
             awayTeam = scores[x].getAttribute('v');
             homeScore = scores[x].getAttribute('hs');
             awayScore = scores[x].getAttribute('vs');
+            timeReamining = scores[x].getAttribute('k');
+            if (timeReamining != null) {
+                quarter = scores[x].getAttribute('q');
+            }
             renderScore();
             return;
         }

--- a/src/options.js
+++ b/src/options.js
@@ -54,7 +54,7 @@ const WEATHER_API_KEY_OPTION = {
 
 const NFL_TEAM_OPTION = {
     elementId: 'nfl-team',
-    defaultValue: '',
+    defaultValue: 'sea',
     storageKey: 'nflTeam',
     loader: loadOrDefault,
     mutator: nflTeamChanged,

--- a/src/options.js
+++ b/src/options.js
@@ -25,6 +25,15 @@ const SHOW_QUOTE_OPTION = {
     property: 'checked'
 }
 
+const SHOW_NFL_OPTION = {
+    elementId: 'switch-nfl',
+    defaultValue: true,
+    storageKey: 'showNFL',
+    loader: loadOrDefaultBoolean,
+    mutator: switchNFLChanged,
+    property: 'checked'
+}
+
 const SHOW_WEATHER_OPTION = {
     elementId: 'switch-weather',
     defaultValue: true,
@@ -40,6 +49,15 @@ const WEATHER_API_KEY_OPTION = {
     storageKey: 'weatherApiKey',
     loader: loadOrDefault,
     mutator: weatherApiKeyChanged,
+    property: 'value'
+}
+
+const NFL_TEAM_OPTION = {
+    elementId: 'nfl-team',
+    defaultValue: '',
+    storageKey: 'nflTeam',
+    loader: loadOrDefault,
+    mutator: nflTeamChanged,
     property: 'value'
 }
 
@@ -66,9 +84,11 @@ const OPTIONS = [
     SHOW_SIDEBAR_OPTION,
     SHOW_CLOCK_OPTION,
     SHOW_QUOTE_OPTION,
+    SHOW_NFL_OPTION,
     SHOW_WEATHER_OPTION,
     ZIPCODE_OPTION,
     WEATHER_API_KEY_OPTION,
+    NFL_TEAM_OPTION,
     UNITS_OPTION
 ]
 
@@ -99,6 +119,10 @@ function switchQuoteChanged(inputEvent) {
     localStorage.setItem(SHOW_QUOTE_OPTION.storageKey, inputEvent.target.checked)
 }
 
+function switchNFLChanged(inputEvent) {
+    localStorage.setItem(SHOW_NFL_OPTION.storageKey, inputEvent.target.checked)
+}
+
 function switchWeatherChanged(inputEvent) {
     localStorage.setItem(SHOW_WEATHER_OPTION.storageKey, inputEvent.target.checked)
 }
@@ -109,6 +133,10 @@ function zipcodeChanged(inputEvent) {
 
 function weatherApiKeyChanged(inputEvent) {
     localStorage.setItem(WEATHER_API_KEY_OPTION.storageKey, inputEvent.target.value)
+}
+
+function nflTeamChanged(inputEvent) {
+    localStorage.setItem(NFL_TEAM_OPTION.storageKey, inputEvent.target.value)
 }
 
 function weatherUnitsChanged(inputEvent) {


### PR DESCRIPTION
Displays game score of current NFL week of a single team in options as well as simple game clock.

I use [this XML Feed](http://www.nfl.com/liveupdate/scorestrip/ss.xml) for the Data. At present if the game isn't on I just say "Not Live" rather than specifying finished or  because I don't know the code for "final".

Added in required options, HTML, and JS.