### PR TITLE
Retire NFL options

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "description": "A new page extension",
 
   "manifest_version": 2,
-  "version": "0.4.0",
+  "version": "0.4.1",
 
   "chrome_url_overrides" : {
     "newtab": "html/happytab.html"

--- a/src/options-data.js
+++ b/src/options-data.js
@@ -1,2 +1,3 @@
+deleteRetiredOptions()
 var options = loadOptionsData()
 

--- a/src/options.js
+++ b/src/options.js
@@ -1,3 +1,16 @@
+const SHOW_NFL_OPTION_RETIRED = {
+    storageKey: 'showNFL',
+}
+
+const NFL_TEAM_OPTION_RETIRED = {
+    storageKey: 'nflTeam',
+}
+
+const RETIRED_OPTIONS = [
+    SHOW_NFL_OPTION_RETIRED,
+    NFL_TEAM_OPTION_RETIRED
+]
+
 const SHOW_SIDEBAR_OPTION = {
     elementId: 'switch-sidebar',
     defaultValue: true,
@@ -155,6 +168,17 @@ function loadOptionsData() {
     })
 
     return data
+}
+
+function deleteRetiredOptions() {
+    RETIRED_OPTIONS.forEach(function(option) {
+        if (!localStorage.getItem(option.storageKey)) {
+            return;
+        }
+
+        console.log("Deleting retired localStorage option " + option.storageKey)
+        localStorage.removeItem(option.storageKey)
+    })
 }
 
 function prepareOptionsUI() {


### PR DESCRIPTION
Add capability to remove localStorage data when an option is no longer used, and utilize this capability to delete the recently-retired NFL options.